### PR TITLE
Update link to official Bazel examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 | :------: | :------: |
 | [![ci status](https://ci.appveyor.com/api/projects/status/7mr1q92rev7h02ca/branch/master?svg=true)](https://ci.appveyor.com/project/limdor/bazel-examples/branch/master) | [![ci status](https://badge.buildkite.com/3787c2c8d9e240573e30b06b5bfa5bd071110fd5fde45a8dd4.svg?branch=master)](https://buildkite.com/bazel/limdor-bazel-examples) |
 
-Bazel examples that extend use cases present in the [official bazel examples](https://github.com/bazelbuild/bazel/tree/master/examples).
+Bazel examples that extend use cases present in the [official bazel examples](https://github.com/bazelbuild/examples).
 Some of these examples are explained also in the presentation [Introduction to Bazel to build C++ and Python](https://www.youtube.com/watch?v=vEQQ9QOVpdU).
 
 List of examples:


### PR DESCRIPTION
Bazel has two places with examples, bazelbuild/build and bazelbuild/examples. The first one is where the examples where originally but the second is where most of the examples are and where they should be long term.

See: https://github.com/bazelbuild/examples/issues/201