### PR TITLE
Add required powershell version

### DIFF
--- a/cpp/ci_execution.ps1
+++ b/cpp/ci_execution.ps1
@@ -1,4 +1,8 @@
-#Requires –Version 7.4
+#Requires –Version 7.3
+If ($PSVersionTable.PSVersion -lt [version]"7.4") {
+    Write-Host "Powershell version lower than 7.4. We need to enable experimental feature PSNativeCommandUseErrorActionPreference"
+    Enable-ExperimentalFeature PSNativeCommandErrorActionPreference
+}
 Set-StrictMode -Version latest
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true

--- a/cpp/ci_execution.ps1
+++ b/cpp/ci_execution.ps1
@@ -1,3 +1,4 @@
+#Requires –Version 7.4
 Set-StrictMode -Version latest
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true


### PR DESCRIPTION
PSNativeCommandUseErrorActionPreference is only available in 7.4 or higher