### PR TITLE
Drop plain CentOS 7 support

### DIFF
--- a/.bazelci/cpp.yml
+++ b/.bazelci/cpp.yml
@@ -30,7 +30,7 @@ tasks:
     <<: *cpp_common
     <<: *cpp_unix_run_targets
   cpp-centos7:
-    platform: centos7
+    platform: centos7_java11_devtoolset10
     <<: *cpp_common
     <<: *cpp_unix_run_targets
   cpp-debian10:

--- a/.bazelci/cpp_and_python.yml
+++ b/.bazelci/cpp_and_python.yml
@@ -32,7 +32,7 @@ tasks:
     <<: *cpp_and_python_common
     <<: *cpp_and_python_unix_run_targets
   cpp-and-python-centos7:
-    platform: centos7
+    platform: centos7_java11_devtoolset10
     <<: *cpp_and_python_common
     <<: *cpp_and_python_unix_run_targets
   cpp-and-python-debian10:

--- a/.bazelci/cpp_coverage.yml
+++ b/.bazelci/cpp_coverage.yml
@@ -30,7 +30,7 @@ tasks:
     <<: *cpp_coverage_common
     <<: *cpp_coverage_unix_run_targets
   cpp-centos7:
-    platform: centos7
+    platform: centos7_java11_devtoolset10
     <<: *cpp_coverage_common
     <<: *cpp_coverage_unix_run_targets
   cpp-debian10:

--- a/.bazelci/python.yml
+++ b/.bazelci/python.yml
@@ -32,7 +32,7 @@ tasks:
     <<: *python_common
     <<: *python_unix_run_targets
   python-centos7:
-    platform: centos7
+    platform: centos7_java11_devtoolset10
     <<: *python_common
     <<: *python_unix_run_targets
   python-debian10:

--- a/.bazelci/third_party_dependencies.yml
+++ b/.bazelci/third_party_dependencies.yml
@@ -30,7 +30,7 @@ tasks:
     <<: *third_party_dependencies_common
     <<: *third_party_dependencies_unix_run_targets
   third-party-dependencies-centos7:
-    platform: centos7
+    platform: centos7_java11_devtoolset10
     <<: *third_party_dependencies_common
     <<: *third_party_dependencies_unix_run_targets
   third-party-dependencies-debian10:


### PR DESCRIPTION
Plan CentOS 7 support was dropped by Bazel
https://github.com/bazelbuild/bazel/issues/13561

Here we do the same and we just support CentOS 7 with gcc 10